### PR TITLE
Do not show window if Start Hiden is on.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,11 +92,10 @@ int main(int argc, char *argv[])
         }
     }
 
-    w.show();
     w.startAutoStartConnections();
 
-    if (w.isHideWindowOnStartup()) {
-        QTimer::singleShot(5, &w, SLOT(hide()));
+    if (!w.isHideWindowOnStartup()) {
+        w.show();
     }
 
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -35,7 +35,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->connectionView->resizeColumnsToContents();
     ui->toolBar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(configHelper->getToolbarStyle()));
 
-    notifier = new StatusNotifier(this, this);
+    notifier = new StatusNotifier(this, this->isHideWindowOnStartup(), this);
 
     connect(configHelper, &ConfigHelper::toolbarStyleChanged, ui->toolBar, &QToolBar::setToolButtonStyle);
     connect(configHelper, &ConfigHelper::rowStatusChanged, this, &MainWindow::onConnectionStatusChanged);
@@ -123,8 +123,11 @@ void MainWindow::onAddScreenQRCode()
 {
     QString uri;
     QList<QScreen *> screens = qApp->screens();
+    int i = 0;
     for (QList<QScreen *>::iterator sc = screens.begin(); sc != screens.end(); ++sc) {
         QImage raw_sc = (*sc)->grabWindow(qApp->desktop()->winId()).toImage();
+        raw_sc.save("/home/glyme/"+QString::number(i)+".png");
+        i++;
         QString result = URIHelper::decodeImage(raw_sc);
         if (!result.isNull()) {
             uri = result;

--- a/src/statusnotifier.h
+++ b/src/statusnotifier.h
@@ -40,7 +40,7 @@ class StatusNotifier : public QObject
 {
     Q_OBJECT
 public:
-    explicit StatusNotifier(MainWindow *w, QObject *parent = 0);
+    explicit StatusNotifier(MainWindow *w, bool startHiden, QObject *parent = 0);
     ~StatusNotifier();
 
     bool isUsingAppIndicator() const;
@@ -53,7 +53,7 @@ public slots:
 private:
 #ifdef Q_OS_UNIX
     GtkWidget *minimiseRestoreGtkItem;
-    void createAppIndicator();
+    void createAppIndicator(bool startHiden);
 #endif
 
     QMenu systrayMenu;


### PR DESCRIPTION
The program fails to hide the window even if Start Hiden is turned on sometimes, especially when added to startup apps in Ubuntu. I modified the code to make the window hidden at the very beginning.